### PR TITLE
Fix: Make templateId optional to support html content emails

### DIFF
--- a/src/BrevoEmailMessage.php
+++ b/src/BrevoEmailMessage.php
@@ -16,7 +16,7 @@ final class BrevoEmailMessage
 
     public array $cc = [];
 
-    public int $templateId;
+    public ?int $templateId = null;
 
     public ?string $subject = null;
 
@@ -161,9 +161,12 @@ final class BrevoEmailMessage
         $data = [
             'sender' => $this->from,
             'to' => $this->to,
-            'templateId' => $this->templateId,
             'params' => $this->params,
         ];
+
+        if (filled($this->templateId)) {
+            $data['templateId'] = $this->templateId;
+        }
 
         if (filled($this->subject)) {
             $data['subject'] = $this->subject;


### PR DESCRIPTION
## Description
Fixes issue where `templateId` was required when sending emails with `htmlContent` as described in #10 

## Changes
- Made `templateId` nullable with default `null`
- Only include `templateId` in API request when set

## Notes
As detailed in the [brevo api docs](https://developers.brevo.com/reference/sendtransacemail), templateId is not always a required field. It's optional if htmlContent is included.

No tests added as none existed for this class previously. Let me know if you'd like test coverage.
