### PR TITLE
return the brevo api response

### DIFF
--- a/src/BrevoEmailChannel.php
+++ b/src/BrevoEmailChannel.php
@@ -15,10 +15,10 @@ class BrevoEmailChannel
     /**
      * @throws BrevoException
      */
-    public function send(Model|AnonymousNotifiable $notifiable, Notification $notification): void
+    public function send(Model|AnonymousNotifiable $notifiable, Notification $notification): array
     {
         $email = $notification->toBrevoEmail($notifiable); // @phpstan-ignore-line
 
-        $this->brevoService->sendEmail($email);
+        return $this->brevoService->sendEmail($email);
     }
 }

--- a/src/BrevoSmsChannel.php
+++ b/src/BrevoSmsChannel.php
@@ -15,10 +15,10 @@ class BrevoSmsChannel
     /**
      * @throws BrevoException
      */
-    public function send(Model|AnonymousNotifiable $notifiable, Notification $notification): void
+    public function send(Model|AnonymousNotifiable $notifiable, Notification $notification): array
     {
         $sms = $notification->toBrevoSms($notifiable); // @phpstan-ignore-line
 
-        $this->brevoService->sendSms($sms);
+        return $this->brevoService->sendSms($sms);
     }
 }

--- a/tests/BrevoEmailChannelTest.php
+++ b/tests/BrevoEmailChannelTest.php
@@ -9,10 +9,18 @@ use YieldStudio\LaravelBrevoNotifier\BrevoService;
 use YieldStudio\LaravelBrevoNotifier\Tests\User;
 
 it('send notification via BrevoEmailChannel should call BrevoService sendEmail method', function () {
-    $mock = $this->mock(BrevoService::class)->shouldReceive('sendEmail')->once();
+    $httpResponse = [
+        'messageId' => '<201906041124.44340027797@smtp-relay.mailin.fr>',
+    ];
+
+    $mock = $this->mock(BrevoService::class)
+        ->shouldReceive('sendEmail')
+        ->once()
+        ->andReturn($httpResponse);
+
     $channel = new BrevoEmailChannel($mock->getMock());
 
-    $channel->send(new User, new class extends Notification
+    $response = $channel->send(new User, new class extends Notification
     {
         public function via()
         {
@@ -24,4 +32,6 @@ it('send notification via BrevoEmailChannel should call BrevoService sendEmail m
             return new BrevoEmailMessage;
         }
     });
+
+    expect($response)->toEqual($httpResponse);
 });

--- a/tests/BrevoSmsChannelTest.php
+++ b/tests/BrevoSmsChannelTest.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Notification as FacadesNotification;
 use YieldStudio\LaravelBrevoNotifier\BrevoService;
 use YieldStudio\LaravelBrevoNotifier\BrevoSmsChannel;
 use YieldStudio\LaravelBrevoNotifier\BrevoSmsMessage;
 use YieldStudio\LaravelBrevoNotifier\Tests\User;
 
 it('send notification via BrevoChannel should call BrevoService sendSms method', function () {
-    $mock = $this->mock(BrevoService::class)->shouldReceive('sendSms')->once();
+    $mock = $this->mock(BrevoService::class)->shouldReceive('sendSms')
+        ->once()
+        ->andReturn(['messageId' => 123]);
+
     $channel = new BrevoSmsChannel($mock->getMock());
-    $channel->send(new User, new class extends Notification
+
+    FacadesNotification::fake();
+
+    $response = $channel->send(new User, new class extends Notification
     {
         public function via()
         {
@@ -24,4 +31,8 @@ it('send notification via BrevoChannel should call BrevoService sendSms method',
             return new BrevoSmsMessage;
         }
     });
+
+    expect($response)->toEqual([
+        'messageId' => 123,
+    ]);
 });


### PR DESCRIPTION
This returns the API response from brevo so that the NotificationSent event will have the response property set.

We are wanting to be able to get the message id so we can store it and then handle delivery webhook events.

Currently the response is not returned.